### PR TITLE
Part4: Support orientation

### DIFF
--- a/SpaceX/Model/MissionModel.swift
+++ b/SpaceX/Model/MissionModel.swift
@@ -16,7 +16,7 @@ struct MissionsDataModel: Decodable, Hashable {
     }
 
     public static func == (lhs: MissionsDataModel, rhs: MissionsDataModel) -> Bool {
-        return lhs.flightNumber == rhs.flightNumber
+        return lhs.missionName == rhs.missionName
     }
 }
 

--- a/SpaceX/View/ContentView.swift
+++ b/SpaceX/View/ContentView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject var viewModel = MissionHistoryViewModel()
+    @State var selectedMission: MissionsDataModel?
+    @State var currentOrientation = UIDevice.current.orientation
 
     init() {
         let navBarAppearance = UINavigationBarAppearance()
@@ -11,33 +13,60 @@ struct ContentView: View {
         UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
     }
 
-    var body: some View {
-        NavigationStack {
-            List {
-                Section {
-                    ForEach(viewModel.missionList, id: \.self) { missionData in
-                        NavigationLink(destination: MissionDetailView(missionData: missionData), label: {
-                            MissionCellView(missionData: missionData)
-                        })
-                    }
-                } header: {
-                    Text(StringConstants.missionListHeader)
-                        .font(.headline)
-                        .fontDesign(.rounded)
-                        .bold()
-                        .foregroundStyle(.black)
-                }
-                
-            }
-            .listStyle(.grouped)
-            .scrollContentBackground(.hidden)
-            .background(.clear)
-            .shadow(radius: 2)
-            .navigationTitle(Text(StringConstants.navigationTitle))
-            .navigationBarTitleDisplayMode(.large)
+    struct ListModifier: ViewModifier {
+        func body(content: Content) -> some View {
+            content
+                .listStyle(.grouped)
+                .shadow(radius: 2)
+                .navigationTitle(Text(StringConstants.navigationTitle))
+                .navigationBarTitleDisplayMode(.large)
         }
-        .onAppear {
-            viewModel.fetchPastLaunchesData()
+    }
+
+    var body: some View {
+        if UIDevice.current.userInterfaceIdiom == .pad && currentOrientation.isLandscape {
+            NavigationSplitView {
+                List(viewModel.missionList, id: \.self, selection: $selectedMission) { missionData in
+                    MissionCellView(missionData: missionData)
+                }
+                .accentColor(.clear)
+                .modifier(ListModifier())
+            } detail: {
+                MissionDetailView(missionData: selectedMission ?? MissionDataModelMock.modelMock)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+                currentOrientation = UIDevice.current.orientation
+            }
+            .onAppear {
+                viewModel.fetchPastLaunchesData()
+            }
+        } else {
+            NavigationStack {
+                List {
+                    Section {
+                        ForEach(viewModel.missionList, id: \.self) { missionData in
+                            NavigationLink(destination: MissionDetailView(missionData: missionData), label: {
+                                MissionCellView(missionData: missionData)
+                            })
+                        }
+                    } header: {
+                        Text(StringConstants.missionListHeader)
+                            .font(.headline)
+                            .fontDesign(.rounded)
+                            .bold()
+                            .foregroundStyle(.black)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+                .background(.clear)
+                .modifier(ListModifier())
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+                currentOrientation = UIDevice.current.orientation
+            }
+            .onAppear {
+                viewModel.fetchPastLaunchesData()
+            }
         }
     }
 }

--- a/SpaceX/View/MissionCellView.swift
+++ b/SpaceX/View/MissionCellView.swift
@@ -19,16 +19,18 @@ struct MissionCellView: View {
         return formatter
     }()
 
-    struct entryView: View {
+    struct EntryView: View {
         var label: String
         var data: String
         var body: some View {
             HStack(alignment: .top) {
                 Text(label)
+                    .foregroundStyle(.black)
                     .font(.caption2)
                     .fontWeight(.bold)
                 Spacer()
                 Text(data)
+                    .foregroundStyle(.black)
                     .font(.caption2)
             }
         }
@@ -36,7 +38,7 @@ struct MissionCellView: View {
 
     // View
     var body: some View {
-        let date = self.formatter.date(from:missionData.launchDateLocal ?? StringConstants.dummyDateFormat)!
+        let date = self.formatter.date(from:missionData.launchDateLocal ?? StringConstants.dummyDateFormat) ?? Date()
         HStack {
             AsyncImage(url: URL(string: missionData.links?.missionPatchSmall ?? StringConstants.dummyImageUrl)) { image in
                         image.resizable()
@@ -51,11 +53,12 @@ struct MissionCellView: View {
                 .padding()
             VStack(alignment: .leading) {
                 Text(missionData.missionName ?? "")
+                    .foregroundStyle(.black)
                     .fontWeight(.bold)
                     .font(.subheadline)
-                entryView(label: StringConstants.rocketLabel, data: missionData.rocket?.rocketName ?? "")
-                entryView(label: StringConstants.siteNameLabel, data: missionData.launchSite?.siteName ?? "")
-                entryView(label: StringConstants.dateLabel, data: "\(self.expectedFormatter.string(from: date))")
+                EntryView(label: StringConstants.rocketLabel, data: missionData.rocket?.rocketName ?? "")
+                EntryView(label: StringConstants.siteNameLabel, data: missionData.launchSite?.siteName ?? "")
+                EntryView(label: StringConstants.dateLabel, data: "\(self.expectedFormatter.string(from: date))")
             }
         }
         .background(.white)

--- a/SpaceX/View/MissionDetailView.swift
+++ b/SpaceX/View/MissionDetailView.swift
@@ -19,7 +19,7 @@ struct MissionDetailView: View {
     }()
 
     // EntryView
-    struct entryView: View {
+    struct EntryView: View {
         var label: String
         var data: String
         var body: some View {
@@ -35,15 +35,14 @@ struct MissionDetailView: View {
     }
 
     var body: some View {
-        let date = self.formatter.date(from:missionData.launchDateLocal ?? StringConstants.dummyDateFormat)!
+        let date = self.formatter.date(from:missionData.launchDateLocal ?? StringConstants.dummyDateFormat) ?? Date()
 
         VStack {
-            Image("Rocket\(missionData.flightNumber % 10)")
-                .resizable()
-                .frame(height: 250)
-
             // Mission detail List
             List {
+                Image("Rocket\(missionData.flightNumber % 10)")
+                    .resizable()
+                    .frame(height: 250)
                 Section {
                     VStack {
                         HStack {
@@ -55,9 +54,9 @@ struct MissionDetailView: View {
                             .frame(width: 100, height: 100)
 
                             VStack {
-                                entryView(label: StringConstants.nameLabel, data: missionData.missionName ?? "")
-                                entryView(label: StringConstants.launchSuccessLabel, data: String(missionData.launchSuccess ?? true))
-                                entryView(label: StringConstants.dateLabel, data: "\(self.expectedFormatter.string(from: date))")
+                                EntryView(label: StringConstants.nameLabel, data: missionData.missionName ?? "")
+                                EntryView(label: StringConstants.launchSuccessLabel, data: String(missionData.launchSuccess ?? true))
+                                EntryView(label: StringConstants.dateLabel, data: "\(self.expectedFormatter.string(from: date))")
                             }
                         }
 
@@ -73,9 +72,9 @@ struct MissionDetailView: View {
                 // Rocket Section
                 Section {
                     VStack {
-                        entryView(label: StringConstants.nameLabel, data: missionData.rocket?.rocketName ?? "")
-                        entryView(label: StringConstants.idLabel, data: missionData.rocket?.rocketId ?? "")
-                        entryView(label: StringConstants.typeLabel, data: missionData.rocket?.rocketType ?? "")
+                        EntryView(label: StringConstants.nameLabel, data: missionData.rocket?.rocketName ?? "")
+                        EntryView(label: StringConstants.idLabel, data: missionData.rocket?.rocketId ?? "")
+                        EntryView(label: StringConstants.typeLabel, data: missionData.rocket?.rocketType ?? "")
                     }
                 } header: {
                     Text(StringConstants.rocketSectionLabel)
@@ -86,9 +85,9 @@ struct MissionDetailView: View {
                 // Site Details Section
                 Section {
                     VStack {
-                        entryView(label: StringConstants.nameLabel, data: missionData.launchSite?.siteName ?? "")
-                        entryView(label: StringConstants.idLabel, data: missionData.launchSite?.siteId ?? "")
-                        entryView(label: StringConstants.addressLabel, data: missionData.launchSite?.siteNameLong ?? "")
+                        EntryView(label: StringConstants.nameLabel, data: missionData.launchSite?.siteName ?? "")
+                        EntryView(label: StringConstants.idLabel, data: missionData.launchSite?.siteId ?? "")
+                        EntryView(label: StringConstants.addressLabel, data: missionData.launchSite?.siteNameLong ?? "")
                     }
                 } header: {
                     Text(StringConstants.siteDetailHeader)
@@ -100,8 +99,8 @@ struct MissionDetailView: View {
                 if let launchSuccess = missionData.launchSuccess, !launchSuccess {
                     Section {
                         VStack {
-                            entryView(label: StringConstants.reasonLabel, data: missionData.launchFailureDetails?.reason ?? "")
-                            entryView(label: StringConstants.timeLabel, data: String(missionData.launchFailureDetails?.time ?? 0)+StringConstants.timeUnitSuffixString)
+                            EntryView(label: StringConstants.reasonLabel, data: missionData.launchFailureDetails?.reason ?? "")
+                            EntryView(label: StringConstants.timeLabel, data: String(missionData.launchFailureDetails?.time ?? 0)+StringConstants.timeUnitSuffixString)
                         }
                     } header: {
                         Text(StringConstants.launchfailureHeader)
@@ -119,6 +118,5 @@ struct MissionDetailView: View {
 }
 
 #Preview {
-//    MissionDetailView(missionData: MissionsDataModel(flightNumber: 1, missionName: "Mission Name", launchDateLocal: "Mission Date", rocket: nil, launchSite: nil, links: nil))
-    ContentView()
+    MissionDetailView(missionData: MissionDataModelMock.modelMock)
 }

--- a/SpaceX/ViewModel/MissionHistoryViewModel.swift
+++ b/SpaceX/ViewModel/MissionHistoryViewModel.swift
@@ -3,6 +3,12 @@ import SwiftUI
 class MissionHistoryViewModel: ObservableObject {
     @Published var missionList: [MissionsDataModel] = []
 
+    var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = ""
+        return formatter
+    }
+
     func fetchPastLaunchesData() {
         NetworkManager.fetchMissionDataFromNetwork { data in
             guard let data else {
@@ -10,7 +16,9 @@ class MissionHistoryViewModel: ObservableObject {
             }
 
             DispatchQueue.main.async {
-                self.missionList.append(contentsOf: data)
+                self.missionList = data.sorted(by: {
+                    $0.launchDateLocal!.compare($1.launchDateLocal!) == .orderedDescending
+                })
             }
         }
     }


### PR DESCRIPTION
## Summary

- Added orientation support for different devices like `iPhone` and `iPad`.
- Refactored code to make it readable.
- Split the window into two parts to show `MissionList` and `MissionDetails` on same window.

## Testing Done

- Tested orientation of app on different devices like `iPhones` and `iPads`.